### PR TITLE
Remove 'docker' dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,6 @@ updates:
     directory: /
     schedule:
       interval: daily
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: daily
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
There is no `Dockerfile` in this repository.