### PR TITLE
Fixing Quay Data Insertion: Avoid Duplicates & Ensure Accuracy

### DIFF
--- a/pkg/database.go
+++ b/pkg/database.go
@@ -27,9 +27,14 @@ func insertComponentData(db *sql.DB, jobID, commit, createdAt string, totalSucce
 
 // insertQuayData inserts a record of Quay image pulls into the database.
 func insertQuayData(db *sql.DB, datetime string, count int, kind string) error {
+	if datetime == "" || kind == "" || count < 0 {
+        return fmt.Errorf("datetime or kind cannot be empty: datetime=%v, kind=%v", datetime, kind)
+    }
 	insertQuery := `
         INSERT INTO aggregated_logs (datetime, count, kind) 
-        VALUES (?, ?, ?);
+        VALUES (?, ?, ?)
+        ON DUPLICATE KEY UPDATE 
+        count = count + VALUES(count);
     `
 	_, err := db.Exec(insertQuery, datetime, count, kind)
 	return err


### PR DESCRIPTION

1. Prevents duplicate entries by updating existing records instead of inserting new ones.

2. Ensures count is correctly aggregated when a duplicate key exists.

3. Improves data consistency in aggregated_logs.
