### PR TITLE
Adding Scheduled Workflow Execution

### DIFF
--- a/.github/workflows/daily-sync.yaml
+++ b/.github/workflows/daily-sync.yaml
@@ -3,6 +3,8 @@ name: Daily Sync
 on:
   push:
     branches: [ main ]
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adding a schedule trigger to the workflow YAML, configuring it to run automatically every day at midnight.
This change enables scheduled execution without requiring manual intervention.