### PR TITLE
Add conditional to prevent running on forks

### DIFF
--- a/.github/workflows/daily-sync.yaml
+++ b/.github/workflows/daily-sync.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   sync-job:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     runs-on: ubuntu-22.04
 
     # Global environment variables for the job


### PR DESCRIPTION
Similar to:
- https://github.com/openshift-kni/eco-goinfra/pull/961
- https://github.com/openshift-kni/eco-goinfra/pull/942
- https://github.com/openshift-kni/eco-gotests/pull/490
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2844

Only run cron jobs on the upstream, no forks.