### PR TITLE
Reset totals per job in DCI components

### DIFF
--- a/pkg/dci.go
+++ b/pkg/dci.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	daysBackLimit = 1 // we want display for 1 day
+	daysBackLimit  = 1 // we want display for 1 day
+	certsuiteTests = "certsuite-tests_junit.xml"
 )
 
 func FetchDciData() error {
@@ -50,11 +51,17 @@ func FetchDciData() error {
 					commitHash = parts[1]
 				}
 				if strings.Contains(component.Name, "cnf-certification-test") || strings.Contains(component.Name, "certsuite") {
+					totalErrors = 0
+					totalFailures = 0
+					totalSkips = 0
+					totalSuccess = 0
 					for _, result := range job.Results {
-						totalErrors += result.Errors
-						totalFailures += result.Failures
-						totalSkips += result.Skips
-						totalSuccess += result.Success
+						if result.Name == certsuiteTests {
+							totalErrors += result.Errors
+							totalFailures += result.Failures
+							totalSkips += result.Skips
+							totalSuccess += result.Success
+						}
 					}
 
 					log.Println("Inserting DCI component data into the database...")


### PR DESCRIPTION
This PR introduces an update to the code that resets the accumulated totals for each job in the dci_components table. Any existing totals for **totalSuccess**, **totalFailures**, **totalErrors**, and **totalSkips** will be cleared, ensuring a fresh start for each job's data.

This update is essential to prevent situations where old data accumulates incorrectly, leading to inaccurate results. 