### PR TITLE
Increase daysBackLimit from 1 to 7

### DIFF
--- a/pkg/dci.go
+++ b/pkg/dci.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	daysBackLimit  = 1 // we want display for 1 day
+	daysBackLimit  = 7 // we want display for 1 day
 	certsuiteTests = "certsuite-tests_junit.xml"
 )
 


### PR DESCRIPTION
This change increases the `daysBackLimit` from 1 to 7 to collect a broader range of DCI data. 