### PR TITLE
docs: add build instructions, prerequisites, and config docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,97 @@
 # certsuite-overview
 
-CertSuite is a dashboard that consolidates data from Quay (image pulls), DCI (test suite runs), and the CertSuite Collector. It automatically updates a centralized MySQL database, offering real-time insights into the usage of CertSuite tools and services. By providing a single, unified view of key metrics, it simplifies monitoring and reporting for stakeholders.
+CertSuite Overview is a CLI tool that consolidates data from Quay (image pulls), DCI (test suite runs), and the CertSuite Collector. It automatically updates a centralized MySQL database, offering real-time insights into the usage of CertSuite tools and services. By providing a single, unified view of key metrics, it simplifies monitoring and reporting for stakeholders.
 
-# Key Features
-1. Quay Image Pull Tracking
-   CertSuite tracks and consolidates image pull data from Quay to monitor repository usage over time.
+## Prerequisites
 
-2. DCI Test Suite Run Tracking
-   Partners running CertSuite via DCI (Distributed CI) will have their test suite executions tracked.
+- **Go 1.26+** (the project uses Go 1.26.1 with toolchain go1.26.3)
+- **MySQL database** for storing consolidated metrics
+- **golangci-lint** (for running the linter)
+- **Quay credentials** (`CLIENTID`, `APISECRET`) for fetching image pull data
+- **DCI credentials** (`BEARERTOKEN`) for fetching test suite run data
 
-3. CertSuite Collector Data Visualization
-- Data collected from the CertSuite Collector—which includes detailed test metrics, execution logs, and other critical statistics—will be visualized.
-- This data, which is already displayed on Grafana dashboards, will now also be integrated into the CertSuite dashboard for a seamless and comprehensive view, including historical tracking.
+## Build
 
-4. Automated MySQL Integration
-- All data streams from Quay, DCI, and the Collector are automatically consolidated into a regularly updated MySQL database.
-- This allows for easy access to all relevant metrics in one location, enabling more efficient data querying, visualization, and real-time reporting.
+```bash
+# Build all packages
+make build
 
-# Data Sources
-1. Quay Image Pulls
-- Tracks the number of image pulls from the CertSuite repository hosted on Quay.
-- Repository: go-quay
-2. DCI Test Suite Runs
-- Monitors the number of CertSuite test suite executions performed by partners via DCI.
-- Repository: go-dci
-3. CertSuite Collector Data
-- Visualizes detailed metrics on test suite executions and related performance data from the CertSuite Collector.
-- Grafana Dashboard: Collector Dashboard
+# Run static analysis
+make vet
 
-# Goals
-The CertSuite Usage Dashboard aims to:
-1. Provide a unified view of CertSuite's usage across multiple platforms.
-2. Ensure that all relevant metrics are easily accessible in one place.
-3. Automate data collection and reporting to reduce manual effort.
+# Run linter
+make lint
+```
 
-# Future Improvements
-1. Integration of additional data sources for deeper insights.
-2. Improved visualizations within the Google Sheet or other platforms like Grafana.
+The build produces a `certsuite-overview` binary from `cmd/main.go`.
+
+## Configuration
+
+Configuration is loaded from environment variables using [Viper](https://github.com/spf13/viper). All variables are required.
+
+| Variable | Description |
+|---|---|
+| `DB_USER` | MySQL database username |
+| `DB_PASSWORD` | MySQL database password |
+| `DB_URL` | MySQL database host/URL |
+| `DB_PORT` | MySQL database port |
+| `CLIENTID` | Quay API client ID |
+| `APISECRET` | Quay API secret |
+| `BEARERTOKEN` | DCI API bearer token |
+| `NAMESPACE` | Quay namespace to query |
+| `REPOSITORY` | Quay repository to query |
+
+Example:
+
+```bash
+export DB_USER=certsuite
+export DB_PASSWORD=secret
+export DB_URL=localhost
+export DB_PORT=3306
+export CLIENTID=quay-client-id
+export APISECRET=quay-api-secret
+export BEARERTOKEN=dci-bearer-token
+export NAMESPACE=redhat-best-practices-for-k8s
+export REPOSITORY=certsuite
+```
+
+## Usage
+
+The CLI uses [Cobra](https://github.com/spf13/cobra) for command management.
+
+```bash
+# Fetch data from Quay and DCI and store it in MySQL
+./certsuite-overview fetch
+```
+
+The `fetch` command pulls image pull statistics from Quay and test suite run data from DCI, then writes the results to the configured MySQL database.
+
+## Grafana Dashboard
+
+The `grafana/` directory contains provisioning files for a Grafana dashboard that visualizes the collected data:
+
+- **`grafana/dashboard/dashboard.json`** -- Dashboard definition with six panels:
+  - Quay Pull Events Over Time
+  - Quay Pull Events by Month
+  - Quay Pull Events by Kind
+  - DCI Test Runs Over Time
+  - DCI Test Runs by Month
+  - DCI Test Cases Ranked by Failures
+- **`grafana/datasource/datasource.yaml`** -- MySQL datasource configuration template (replace `DB_URL`, `DB_PORT`, `DB_USER`, and `DB_PASSWORD` placeholders with actual values)
+
+To use, import the dashboard JSON into your Grafana instance and configure the MySQL datasource to point at the same database used by the CLI.
+
+## Key Features
+
+1. **Quay Image Pull Tracking** -- Tracks and consolidates image pull data from Quay to monitor repository usage over time.
+2. **DCI Test Suite Run Tracking** -- Partners running CertSuite via DCI (Distributed CI) have their test suite executions tracked.
+3. **CertSuite Collector Data Visualization** -- Data collected from the CertSuite Collector is visualized through the Grafana dashboard, including historical tracking.
+4. **Automated MySQL Integration** -- All data streams from Quay, DCI, and the Collector are automatically consolidated into a regularly updated MySQL database.
+
+## Data Sources
+
+| Source | Description | Library |
+|---|---|---|
+| Quay Image Pulls | Tracks image pull counts from the CertSuite Quay repository | [go-quay](https://github.com/sebrandon1/go-quay) |
+| DCI Test Suite Runs | Monitors CertSuite test executions performed via DCI | [go-dci](https://github.com/sebrandon1/go-dci) |
+| CertSuite Collector | Detailed test metrics and execution statistics | Grafana dashboard |


### PR DESCRIPTION
## Summary

- Add Prerequisites section listing Go 1.26+, MySQL, golangci-lint, and required API credentials
- Add Build section documenting all Makefile targets (build, vet, lint)
- Add Configuration section with a table of all required environment variables and an example
- Add Usage section showing CLI commands
- Add Grafana Dashboard section documenting the dashboard JSON and datasource template in grafana/
- Reorganize existing Key Features and Data Sources into cleaner formatting

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all documented env vars match config/config.go
- [ ] Confirm Makefile targets match actual Makefile